### PR TITLE
Ensure all STOMP commands are specification compliant (#35)

### DIFF
--- a/coilmq/protocol/__init__.py
+++ b/coilmq/protocol/__init__.py
@@ -8,22 +8,6 @@ from coilmq.util import frames
 from coilmq.util.frames import Frame, ErrorFrame, ReceiptFrame, ConnectedFrame
 from coilmq.util.concurrency import CoilThreadingTimer
 
-SEND = 'SEND'
-CONNECT = 'CONNECT'
-MESSAGE = 'MESSAGE'
-ERROR = 'ERROR'
-CONNECTED = 'CONNECTED'
-SUBSCRIBE = 'SUBSCRIBE'
-UNSUBSCRIBE = 'UNSUBSCRIBE'
-BEGIN = 'BEGIN'
-COMMIT = 'COMMIT'
-ABORT = 'ABORT'
-ACK = 'ACK'
-DISCONNECT = 'DISCONNECT'
-
-VALID_COMMANDS = ['message', 'connect', 'connected', 'error', 'send',
-                  'subscribe', 'unsubscribe', 'begin', 'commit', 'abort', 'ack', 'disconnect', 'nack', 'stomp']
-
 
 class STOMP(object):
 
@@ -85,12 +69,11 @@ class STOMP10(STOMP):
         @param frame: The frame that was received.
         @type frame: C{stompclient.frame.Frame}
         """
-        cmd_method = frame.cmd.lower()
 
-        if not cmd_method in VALID_COMMANDS:
+        if frame.cmd not in frames.VALID_COMMANDS:
             raise ProtocolError("Invalid STOMP command: {}".format(frame.cmd))
 
-        method = getattr(self, cmd_method, None)
+        method = getattr(self, frame.cmd.lower(), None)
 
         if not self.engine.connected and method not in (self.connect, self.stomp):
             raise ProtocolError("Not connected.")

--- a/coilmq/queue.py
+++ b/coilmq/queue.py
@@ -11,6 +11,7 @@ from collections import defaultdict
 
 from coilmq.scheduler import FavorReliableSubscriberScheduler, RandomQueueScheduler
 from coilmq.subscription import SubscriptionManager, Subscription
+from coilmq.util import frames
 from coilmq.util.concurrency import synchronized
 
 __authors__ = ['"Hans Lellelid" <hans@xmpl.org>']
@@ -189,7 +190,7 @@ class QueueManager(object):
             raise ValueError(
                 "Cannot send frame with no destination: %s" % message)
 
-        message.cmd = 'message'
+        message.cmd = frames.MESSAGE
 
         message.headers.setdefault('message-id', str(uuid.uuid4()))
 
@@ -355,7 +356,7 @@ class QueueManager(object):
         assert subscription is not None
         assert frame is not None
 
-        if frame.cmd == "message":
+        if frame.cmd == frames.MESSAGE:
             frame.headers["subscription"] = subscription.id
 
         self.log.debug("Delivering frame %s to subscription %s" %

--- a/coilmq/topic.py
+++ b/coilmq/topic.py
@@ -9,6 +9,7 @@ import threading
 import uuid
 from copy import deepcopy
 from coilmq.subscription import SubscriptionManager
+from coilmq.util import frames
 from coilmq.util.concurrency import synchronized
 
 __authors__ = ['"Hans Lellelid" <hans@xmpl.org>']
@@ -116,7 +117,7 @@ class TopicManager(object):
             raise ValueError(
                 "Cannot send frame with no destination: %s" % message)
 
-        message.cmd = 'message'
+        message.cmd = frames.MESSAGE
 
         message.headers.setdefault('message-id', str(uuid.uuid4()))
 

--- a/coilmq/util/frames.py
+++ b/coilmq/util/frames.py
@@ -18,10 +18,11 @@ COMMIT = 'COMMIT'
 ABORT = 'ABORT'
 ACK = 'ACK'
 NACK = 'NACK'
+STOMP_CMD = 'STOMP'
 DISCONNECT = 'DISCONNECT'
 
-VALID_COMMANDS = ['message', 'connect', 'connected', 'error', 'send',
-                  'subscribe', 'unsubscribe', 'begin', 'commit', 'abort', 'ack', 'disconnect', 'nack']
+VALID_COMMANDS = [MESSAGE, CONNECT, CONNECTED, ERROR, SEND,
+                  SUBSCRIBE, UNSUBSCRIBE, BEGIN, COMMIT, ABORT, ACK, DISCONNECT, NACK, STOMP_CMD]
 
 TEXT_PLAIN = 'text/plain'
 
@@ -142,7 +143,7 @@ class ConnectedFrame(Frame):
         @type session: C{str}
         """
         super(ConnectedFrame, self).__init__(
-            cmd='connected', headers=extra_headers or {})
+            cmd=CONNECTED, headers=extra_headers or {})
         self.headers['session'] = session
 
 
@@ -197,7 +198,7 @@ class ErrorFrame(Frame):
         @param body: The message body bytes.
         @type body: C{str}
         """
-        super(ErrorFrame, self).__init__(cmd='error',
+        super(ErrorFrame, self).__init__(cmd=ERROR,
                                          headers=extra_headers or {}, body=body)
         self.headers['message'] = message
         self.headers[

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -3,3 +3,4 @@ fakeredis
 mock
 pytest
 pytest-cov
+dataclasses

--- a/tests/functional/__init__.py
+++ b/tests/functional/__init__.py
@@ -185,10 +185,10 @@ class TestStompClient(object):
         headers['destination'] = destination
         if set_content_length:
             headers['content-length'] = len(message)
-        self.send_frame(Frame('send', headers=headers, body=message))
+        self.send_frame(Frame(frames.SEND, headers=headers, body=message))
 
     def subscribe(self, destination):
-        self.send_frame(Frame('subscribe', headers={
+        self.send_frame(Frame(frames.SUBSCRIBE, headers={
                         'destination': destination}))
 
     def send_frame(self, frame):
@@ -223,7 +223,7 @@ class TestStompClient(object):
         # print "Read loop has been quit! for %s" % id(self)
 
     def disconnect(self):
-        self.send_frame(Frame('disconnect'))
+        self.send_frame(Frame(frames.DISCONNECT))
 
     def close(self):
         if not self.connected:

--- a/tests/functional/test_basic.py
+++ b/tests/functional/test_basic.py
@@ -42,20 +42,20 @@ class BasicTest(BaseFunctionalTestCase):
         c1 = self._new_client(connect=False)
         c1.connect()
         r = c1.received_frames.get(timeout=1)
-        self.assertEqual(r.cmd, 'error')
+        self.assertEqual(r.cmd, frames.ERROR)
         self.assertIn(b'Auth', r.body)
 
         c2 = self._new_client(connect=False)
         c2.connect(headers={'login': 'user', 'passcode': 'pass'})
         r2 = c2.received_frames.get(timeout=1)
 
-        self.assertEqual(r2.cmd.lower(), 'connected')
+        self.assertEqual(r2.cmd, frames.CONNECTED)
 
         c3 = self._new_client(connect=False)
         c3.connect(headers={'login': 'user', 'passcode': 'pass-invalid'})
         r3 = c3.received_frames.get(timeout=1)
 
-        self.assertEqual(r3.cmd, 'error')
+        self.assertEqual(r3.cmd, frames.ERROR)
 
     def test_send_receipt(self):
         c1 = self._new_client()
@@ -73,7 +73,7 @@ class BasicTest(BaseFunctionalTestCase):
         self.assertEqual(c2.received_frames.qsize(), 0)
 
         r = c1.received_frames.get()
-        self.assertEqual(r.cmd, 'message')
+        self.assertEqual(r.cmd, frames.MESSAGE)
         self.assertEqual(r.body, b'A message')
 
     def test_disconnect(self):
@@ -101,7 +101,7 @@ class BasicTest(BaseFunctionalTestCase):
         c2.send('/queue/foo', zlib.compress(message))
 
         res = c1.received_frames.get()
-        self.assertEqual(res.cmd, 'message')
+        self.assertEqual(res.cmd, frames.MESSAGE)
         self.assertEqual(zlib.decompress(res.body), message)
 
     def test_send_utf8(self):
@@ -119,5 +119,5 @@ class BasicTest(BaseFunctionalTestCase):
         c2.send('/queue/foo', utf8msg)
 
         res = c1.received_frames.get()
-        self.assertEqual(res.cmd, 'message')
+        self.assertEqual(res.cmd, frames.MESSAGE)
         self.assertEqual(res.body, utf8msg)

--- a/tests/protocol/test_stomp_1_2.py
+++ b/tests/protocol/test_stomp_1_2.py
@@ -18,12 +18,12 @@ class STOMP12TestCase(ProtocolBaseTestCase):
     def test_host_invalid(self):
         host = 'nothing.nowhere.com'
         response = self.feed_frame(frames.CONNECT, {'host': host, 'accept-version': '1.2'})
-        self.assertEqual(response.cmd, frames.ERROR.lower())
+        self.assertEqual(response.cmd, frames.ERROR)
         self.assertEqual(response.headers['message'], 'Virtual hosting is not supported or host is unknown')
 
     def test_no_host_header(self):
         response = self.feed_frame(frames.CONNECT, {'accept-version': '1.2'})
-        self.assertEqual(response.cmd, frames.ERROR.lower())
+        self.assertEqual(response.cmd, frames.ERROR)
         self.assertEqual(response.headers['message'], '"host" header is required')
 
     def test_protocol_downgrade(self):

--- a/tests/store/__init__.py
+++ b/tests/store/__init__.py
@@ -4,6 +4,7 @@ Queue storage tests.
 import unittest
 import uuid
 
+from coilmq.util import frames
 from coilmq.util.frames import Frame
 
 __authors__ = ['"Hans Lellelid" <hans@xmpl.org>']
@@ -31,7 +32,7 @@ class CommonQueueTest(object):
     def test_enqueue(self):
         """ Test the enqueue() method. """
         dest = '/queue/foo'
-        frame = Frame('MESSAGE', headers={
+        frame = Frame(frames.MESSAGE, headers={
                       'message-id': str(uuid.uuid4())}, body='some data')
         self.store.enqueue(dest, frame)
 
@@ -41,7 +42,7 @@ class CommonQueueTest(object):
     def test_dequeue(self):
         """ Test the dequeue() method. """
         dest = '/queue/foo'
-        frame = Frame('MESSAGE', headers={
+        frame = Frame(frames.MESSAGE, headers={
                       'message-id': str(uuid.uuid4())}, body='some data')
         self.store.enqueue(dest, frame)
 
@@ -62,15 +63,15 @@ class CommonQueueTest(object):
         dest = '/queue/foo'
         notdest = '/queue/other'
 
-        frame1 = Frame('MESSAGE', headers={
+        frame1 = Frame(frames.MESSAGE, headers={
                        'message-id': str(uuid.uuid4())}, body='message-1')
         self.store.enqueue(dest, frame1)
 
-        frame2 = Frame('MESSAGE', headers={
+        frame2 = Frame(frames.MESSAGE, headers={
                        'message-id': str(uuid.uuid4())}, body='message-2')
         self.store.enqueue(notdest, frame2)
 
-        frame3 = Frame('MESSAGE', headers={
+        frame3 = Frame(frames.MESSAGE, headers={
                        'message-id': str(uuid.uuid4())}, body='message-3')
         self.store.enqueue(dest, frame3)
 
@@ -90,15 +91,15 @@ class CommonQueueTest(object):
         """ Test the order that frames are returned by dequeue() method. """
         dest = '/queue/foo'
 
-        frame1 = Frame('MESSAGE', headers={
+        frame1 = Frame(frames.MESSAGE, headers={
                        'message-id': str(uuid.uuid4())}, body='message-1')
         self.store.enqueue(dest, frame1)
 
-        frame2 = Frame('MESSAGE', headers={
+        frame2 = Frame(frames.MESSAGE, headers={
                        'message-id': str(uuid.uuid4())}, body='message-2')
         self.store.enqueue(dest, frame2)
 
-        frame3 = Frame('MESSAGE', headers={
+        frame3 = Frame(frames.MESSAGE, headers={
                        'message-id': str(uuid.uuid4())}, body='message-3')
         self.store.enqueue(dest, frame3)
 

--- a/tests/store/test_dbm.py
+++ b/tests/store/test_dbm.py
@@ -8,6 +8,7 @@ import unittest
 import uuid
 
 from coilmq.store.dbm import DbmQueue
+from coilmq.util import frames
 from coilmq.util.frames import Frame
 from tests.store import CommonQueueTest
 
@@ -39,7 +40,7 @@ class DbmQueueTest(CommonQueueTest, unittest.TestCase):
     def test_dequeue_identity(self):
         """ Test the dequeue() method. """
         dest = '/queue/foo'
-        frame = Frame('MESSAGE', headers={
+        frame = Frame(frames.MESSAGE, headers={
                       'message-id': str(uuid.uuid4())}, body='some data')
         self.store.enqueue(dest, frame)
 
@@ -63,7 +64,7 @@ class DbmQueueTest(CommonQueueTest, unittest.TestCase):
             dest = '/queue/foo'
 
             for i in range(max_ops + 1):
-                frame = Frame('MESSAGE', headers={
+                frame = Frame(frames.MESSAGE, headers={
                               'message-id': str(uuid.uuid4())}, body='some data - %d' % i)
                 store.enqueue(dest, frame)
 
@@ -86,13 +87,13 @@ class DbmQueueTest(CommonQueueTest, unittest.TestCase):
             store = DbmQueue(data_dir, checkpoint_timeout=0.5)
             dest = '/queue/foo'
 
-            frame = Frame('MESSAGE', headers={
+            frame = Frame(frames.MESSAGE, headers={
                           'message-id': str(uuid.uuid4())}, body='some data -1')
             store.enqueue(dest, frame)
 
             time.sleep(0.5)
 
-            frame = Frame('MESSAGE', headers={
+            frame = Frame(frames.MESSAGE, headers={
                           'message-id': str(uuid.uuid4())}, body='some data -2')
             store.enqueue(dest, frame)
 
@@ -114,7 +115,7 @@ class DbmQueueTest(CommonQueueTest, unittest.TestCase):
         try:
             store = DbmQueue(data_dir)
             dest = '/queue/foo'
-            frame = Frame('MESSAGE', headers={
+            frame = Frame(frames.MESSAGE, headers={
                           'message-id': str(uuid.uuid4())}, body='some data')
             store.enqueue(dest, frame)
             self.assertEqual(store.size(dest), 1)
@@ -135,7 +136,7 @@ class DbmQueueTest(CommonQueueTest, unittest.TestCase):
         try:
             store = DbmQueue(data_dir)
             dest = '/queue/foo'
-            frame = Frame('MESSAGE', headers={
+            frame = Frame(frames.MESSAGE, headers={
                           'message-id': str(uuid.uuid4())}, body='some data')
             store.enqueue(dest, frame)
             self.assertEqual(store.size(dest), 1)

--- a/tests/store/test_memory.py
+++ b/tests/store/test_memory.py
@@ -5,6 +5,7 @@ import unittest
 import uuid
 
 from coilmq.store.memory import MemoryQueue
+from coilmq.util import frames
 from coilmq.util.frames import Frame
 from tests.store import CommonQueueTest
 
@@ -31,7 +32,7 @@ class MemoryQueueTest(CommonQueueTest, unittest.TestCase):
     def test_dequeue_identity(self):
         """ Test the dequeue() method. """
         dest = '/queue/foo'
-        frame = Frame('MESSAGE', headers={
+        frame = Frame(frames.MESSAGE, headers={
                       'message-id': str(uuid.uuid4())}, body='some data')
         self.store.enqueue(dest, frame)
 

--- a/tests/store/test_sa.py
+++ b/tests/store/test_sa.py
@@ -9,6 +9,7 @@ from sqlalchemy import create_engine
 from coilmq.store.sa import SAQueue
 from coilmq.store.sa import init_model
 from coilmq.store.sa import meta, model
+from coilmq.util import frames
 from coilmq.util.frames import Frame
 from tests.store import CommonQueueTest
 
@@ -41,15 +42,15 @@ class SAQueueTest(CommonQueueTest, unittest.TestCase):
         """ Test the order that frames are returned by dequeue() method. """
         dest = '/queue/foo'
 
-        frame1 = Frame('MESSAGE', headers={
+        frame1 = Frame(frames.MESSAGE, headers={
                        'message-id': 'id-1'}, body='message-1')
         self.store.enqueue(dest, frame1)
 
-        frame2 = Frame('MESSAGE', headers={
+        frame2 = Frame(frames.MESSAGE, headers={
                        'message-id': 'id-2'}, body='message-2')
         self.store.enqueue(dest, frame2)
 
-        frame3 = Frame('MESSAGE', headers={
+        frame3 = Frame(frames.MESSAGE, headers={
                        'message-id': 'id-3'}, body='message-3')
         self.store.enqueue(dest, frame3)
 

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -46,7 +46,7 @@ class TestFrameBuffer(unittest.TestCase):
         """ Test extracting a single frame. """
         sb = FrameBuffer()
         m1 = self.createMessage(
-            'connect', {'session': uuid.uuid4()}, 'This is the body')
+            frames.CONNECT, {'session': uuid.uuid4()}, 'This is the body')
         sb.append(m1)
         msg = sb.extract_frame()
         self.assertIsInstance(msg, Frame)
@@ -56,7 +56,7 @@ class TestFrameBuffer(unittest.TestCase):
         """ Test extracting a binary frame. """
         sb = FrameBuffer()
         binmsg = "\x00\x00HELLO\x00\x00DONKEY\x00\x00"
-        m1 = self.createMessage('send', OrderedDict({'content-length': len(binmsg), 'x-other-header': 'value'}), binmsg
+        m1 = self.createMessage(frames.SEND, OrderedDict({'content-length': len(binmsg), 'x-other-header': 'value'}), binmsg
                                 )
         sb.append(m1)
         msg = sb.extract_frame()

--- a/tests/test_topic.py
+++ b/tests/test_topic.py
@@ -72,7 +72,7 @@ class TopicManagerTest(unittest.TestCase):
 
         # Assert some side-effects
         self.assertIn('message-id', f.headers)
-        self.assertEqual(f.cmd, 'message')
+        self.assertEqual(f.cmd, frames.MESSAGE)
 
     def test_send_subscriber_timeout(self):
         """ Test a send command when one subscriber errs out. """
@@ -94,7 +94,7 @@ class TopicManagerTest(unittest.TestCase):
         self.tm.subscribe(bad_client, dest)
         self.tm.subscribe(self.conn, dest)
 
-        f = Frame('message', headers={'destination': dest}, body='Empty')
+        f = Frame(frames.MESSAGE, headers={'destination': dest}, body='Empty')
         self.tm.send(f)
 
         # Make sure out good client got the message.


### PR DESCRIPTION
* ensure STOMP commands are uppercase

* clean up duplicated definitions

* update tests to uppercase commands

... and parametrize test cases